### PR TITLE
fix: change undefined helm values to correct types

### DIFF
--- a/admin-tools/base/resources.yaml
+++ b/admin-tools/base/resources.yaml
@@ -199,7 +199,8 @@ spec:
       name: taco-clair
       deployment:
         replicas: 1
-        hostAliases: TO_BE_FIXED 
+        hostAliases:
+        - TO_BE_FIXED 
           # - ip: "10.10.10.15"
           #   hostnames:  
           #   - """
@@ -239,7 +240,8 @@ spec:
         data:
           size: 100Mi
           path: /var/run/docker.sock
-      mirrors: TO_BE_FIXED
+      mirrors:
+      - TO_BE_FIXED
         # - ip:  192.168.0.1
         #   host: registry-1.com
 
@@ -252,7 +254,8 @@ spec:
           # - ip: 1.1.1.1
           #   hostnames: 
           #   - "keycloak"
-        env: TO_BE_FIXED 
+        env:
+        - TO_BE_FIXED 
           # - name: KEYCLOAK_AUTH_SERVER_URI
           #   value: "https://keycloak"
           # - name: KEYCLOAK_CLIENT_ID

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -38,7 +38,8 @@ spec:
       enabled: false
     prometheusOperator:
       enabled: true
-      nodeSelector: TO_BE_FIXED
+      nodeSelector:
+        TO_BE_FIXED: TO_BE_FIXED
       createCustomResource: true
       cleanupCustomResource: true
       cleanupCustomResourceBeforeInstall: true
@@ -188,7 +189,8 @@ spec:
   values:
     alertmanager:
       alertmanagerSpec:
-        nodeSelector: TO_BE_FIXED
+        nodeSelector:
+          TO_BE_FIXED: TO_BE_FIXED
         retention: TO_BE_FIXED
       config:
         global:
@@ -284,7 +286,8 @@ spec:
       prometheusSpec:
         externalLabels:
           taco_cluster: federation-master
-        nodeSelector: TO_BE_FIXED
+        nodeSelector:
+          TO_BE_FIXED: TO_BE_FIXED
         replicas: 1
         ruleNamespaceSelector:
           matchLabels:
@@ -329,7 +332,8 @@ spec:
   releaseName: kube-state-metrics
   targetNamespace: lma
   values:
-    nodeSelector: TO_BE_FIXED
+    nodeSelector:
+      TO_BE_FIXED: TO_BE_FIXED
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -367,7 +371,8 @@ spec:
     service:
       nodePort: 30010
       type: NodePort
-    nodeSelector: TO_BE_FIXED
+    nodeSelector:
+      TO_BE_FIXED: TO_BE_FIXED
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -435,7 +440,8 @@ spec:
         nodeSets:
           master:
             enabled: true
-            nodeSelector: TO_BE_FIXED
+            nodeSelector:
+              TO_BE_FIXED: TO_BE_FIXED
             count: 3
             javaOpts: TO_BE_FIXED
             limitCpu: TO_BE_FIXED
@@ -445,7 +451,8 @@ spec:
               size: TO_BE_FIXED
           hotdata:
             enabled: true
-            nodeSelector: TO_BE_FIXED
+            nodeSelector:
+              TO_BE_FIXED: TO_BE_FIXED
             count: 3
             javaOpts: TO_BE_FIXED
             limitCpu: TO_BE_FIXED
@@ -455,7 +462,8 @@ spec:
               size: TO_BE_FIXED
           warmdata:
             enabled: TO_BE_FIXED
-            nodeSelector: TO_BE_FIXED
+            nodeSelector:
+              TO_BE_FIXED: TO_BE_FIXED
             count: 2
             javaOpts: TO_BE_FIXED
             limitCpu: TO_BE_FIXED
@@ -465,7 +473,8 @@ spec:
               size: TO_BE_FIXED
           client:
             enabled: TO_BE_FIXED
-            nodeSelector: TO_BE_FIXED
+            nodeSelector:
+              TO_BE_FIXED: TO_BE_FIXED
             count: TO_BE_FIXED
             javaOpts: TO_BE_FIXED
             limitCpu: TO_BE_FIXED
@@ -490,7 +499,8 @@ spec:
                 port: 5601
         limitCpu: TO_BE_FIXED
         limitMem: TO_BE_FIXED
-        nodeSelector: TO_BE_FIXED
+        nodeSelector:
+          TO_BE_FIXED: TO_BE_FIXED
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -554,7 +564,8 @@ spec:
       enabled: true
       createCustomResource: true
       cleanupCustomResource: true
-      nodeSelector: TO_BE_FIXED
+      nodeSelector:
+        TO_BE_FIXED: TO_BE_FIXED
       resources:
         limits:
           cpu: "2"
@@ -566,7 +577,8 @@ spec:
       enabled: false
     logExporter:
       enabled: true
-      nodeSelector: TO_BE_FIXED
+      nodeSelector:
+        TO_BE_FIXED: TO_BE_FIXED
       serviceMonitor:
         enabled: false
         interval: 1m
@@ -589,7 +601,8 @@ spec:
   values:
     global:
       base_cluster_url: TO_BE_FIXED   #FIXME
-      nodeSelector: TO_BE_FIXED
+      nodeSelector:
+        TO_BE_FIXED: TO_BE_FIXED
     fluentbitOperator:
       enabled: false
       createCustomResource: false
@@ -790,7 +803,8 @@ spec:
         value: kibana|elasticsearch|fluent-bit
       alerts:
         makeAlertRule: true
-      nodeSelector: TO_BE_FIXED
+      nodeSelector:
+        TO_BE_FIXED: TO_BE_FIXED
     fluentbitOperator:
       enabled: false
       createCustomResource: false
@@ -871,7 +885,8 @@ spec:
       kibana:
         host: TO_BE_FIXED
       prometheus:
-        hosts: TO_BE_FIXED
+        hosts:
+        - TO_BE_FIXED
       addtionalModules: []
     grafanaDashboard:
       enabled: true
@@ -892,7 +907,8 @@ spec:
         enabled: false
       nodeExporter:
         enabled: false
-      federations: TO_BE_FIXED
+      federations:
+      - TO_BE_FIXED
     tacoWatcher:
       host: TO_BE_FIXED
       port: 32000
@@ -936,7 +952,8 @@ spec:
       port: 9090
     rules:
       default: false
-    nodeSelector: TO_BE_FIXED
+    nodeSelector:
+      TO_BE_FIXED: TO_BE_FIXED
   wait: true
 ---
 apiVersion: helm.fluxcd.io/v1
@@ -957,7 +974,8 @@ spec:
       logLevel: error     # possible level: error, debug,
       logFormat: json
       default:
-        hosts: TO_BE_FIXED  #[]
+        hosts:
+        - TO_BE_FIXED 
         index: kube-events
         user: elastic
         password: tacoword

--- a/lma/base/site-values.yaml
+++ b/lma/base/site-values.yaml
@@ -185,4 +185,5 @@ charts:
   source:
     repository: $(repository)
   override:
-    conf.default.hosts: TO_BE_FIXED
+    conf.default.hosts:
+    - TO_BE_FIXED

--- a/openstack/base/resources.yaml
+++ b/openstack/base/resources.yaml
@@ -369,7 +369,8 @@ spec:
       configmap_etc: true
       daemonset_libvirt: true
     network:
-      backend: TO_BE_FIXED
+      backend:
+      - TO_BE_FIXED
     release_group: null
   wait: true
 ---
@@ -554,7 +555,8 @@ spec:
       daemonset_ovs_agent: false
       daemonset_sriov_agent: false
     network:
-      backend: TO_BE_FIXED
+      backend:
+      - TO_BE_FIXED
       server:
         node_port:
           enabled: true
@@ -718,7 +720,8 @@ spec:
     manifests:
       statefulset_compute_ironic: true
     network:
-      backend: TO_BE_FIXED
+      backend:
+      - TO_BE_FIXED
       novncproxy:
         name: nova-novncproxy
         node_port:
@@ -1103,7 +1106,8 @@ spec:
     controller:
       master: TO_BE_FIXED
       slave: TO_BE_FIXED
-    hosts: TO_BE_FIXED
+    hosts:
+    - TO_BE_FIXED
     onos:
       config:
         ovsdb_port: TO_BE_FIXED


### PR DESCRIPTION
* In kustomize v3.8.7, strict type checking is enabled.
* So it has to be same type of HelmRelease values in resources.yaml as output.yaml.