### PR TITLE
align with new env. on github.com

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -808,7 +808,7 @@ metadata:
 spec:
   chart:
     repository: TO_BE_FIXED
-    name: taco-addons-lma
+    name: lma-addons
     version: 1.0.6
   releaseName: addons
   targetNamespace: lma
@@ -857,7 +857,7 @@ metadata:
 spec:
   chart:
     repository: TO_BE_FIXED
-    name: taco-addons-lma
+    name: lma-addons
     version: 1.0.6
   releaseName: fed-addons
   targetNamespace: fed

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: prometheus-operator
-    version: 8.12.3
+    version: 9.3.2
   releaseName: prometheus-operator
   targetNamespace: lma
   values:
@@ -81,7 +81,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: prometheus-operator
-    version: 8.12.3
+    version: 9.3.2
   releaseName: prometheus
   targetNamespace: lma
   values:
@@ -182,7 +182,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: prometheus-operator
-    version: 8.12.3
+    version: 9.3.2
   releaseName: prometheus-fed-master
   targetNamespace: fed
   values:

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -325,7 +325,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: kube-state-metrics
-    version: 2.8.2
+    version: 2.9.4
   releaseName: kube-state-metrics
   targetNamespace: lma
   values:
@@ -342,7 +342,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: prometheus-node-exporter
-    version: 1.9.1
+    version: 1.11.2
   releaseName: prometheus-node-exporter
   targetNamespace: lma
   values:
@@ -360,7 +360,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: prometheus-pushgateway
-    version: 1.3.0 
+    version: 1.4.3
   releaseName: prometheus-pushgateway
   targetNamespace: lma
   values:
@@ -503,7 +503,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: grafana
-    version: 5.0.7
+    version: 5.5.7
   releaseName: grafana
   targetNamespace: fed
   values:
@@ -927,7 +927,7 @@ spec:
   chart:
     repository: TO_BE_FIXED
     name: prometheus-adapter
-    version: 2.1.3 
+    version: 2.5.1
   releaseName: prometheus-adapter
   targetNamespace: lma
   values:

--- a/lma/image/image-values.yaml
+++ b/lma/image/image-values.yaml
@@ -63,7 +63,8 @@ charts:
     image.tag: 6.6.2
     initChownData.image.repository: $(registry)/library/busybox
     initChownData.image.tag: 1.31.1
-    sidecar.image: $(registry)/k8s-sidecar:0.1.99
+    sidecar.image.repository: $(registry)/k8s-sidecar
+    sidecar.image.tag: 0.1.151
     testFramework.image: $(registry)/bats
     testFramework.tag: v1.1.0
 


### PR DESCRIPTION
이전 버전의 helm chart 들이 업그레이드 되어 이렇게 맞춥니다.

참고로 hanu-helm-repos는 그냥 master에 push해서 등록했습니다. (기존 내역 수정은 없고 추가만 함)