### PR TITLE
prometheus-alertmanager does not support hipchat anymore

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -192,8 +192,6 @@ spec:
         retention: TO_BE_FIXED
       config:
         global:
-          hipchat_api_url: null
-          hipchat_auth_token: null
           slack_api_url: TO_BE_FIXED
           smtp_auth_password: null
           smtp_auth_username: null


### PR DESCRIPTION
hipchat 지원 사라지면서 기존 들어있던 내역에 문제를 일으킴
