### PR TITLE
[Bugfix] fix default boolean value

### DIFF
--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -437,7 +437,7 @@ spec:
     customResource:
       elasticsearch:
         version: 7.5.1
-        enabled: true
+        enabled: true 
         count: 3        # FIXME
         nodeSets:
           master:
@@ -461,7 +461,7 @@ spec:
               storageClassName: TO_BE_FIXED
               size: TO_BE_FIXED
           warmdata:
-            enabled: false
+            enabled: false # TO_BE_FIXED
             nodeSelector: {} # TO_BE_FIXED
             count: 2
             javaOpts: TO_BE_FIXED
@@ -471,7 +471,7 @@ spec:
               storageClassName: TO_BE_FIXED
               size: TO_BE_FIXED
           client:
-            enabled: true
+            enabled: true # TO_BE_FIXED
             nodeSelector: {} # TO_BE_FIXED
             count: TO_BE_FIXED
             javaOpts: TO_BE_FIXED

--- a/lma/base/resources.yaml
+++ b/lma/base/resources.yaml
@@ -461,7 +461,7 @@ spec:
               storageClassName: TO_BE_FIXED
               size: TO_BE_FIXED
           warmdata:
-            enabled: TO_BE_FIXED
+            enabled: false
             nodeSelector: {} # TO_BE_FIXED
             count: 2
             javaOpts: TO_BE_FIXED
@@ -471,7 +471,7 @@ spec:
               storageClassName: TO_BE_FIXED
               size: TO_BE_FIXED
           client:
-            enabled: TO_BE_FIXED
+            enabled: true
             nodeSelector: {} # TO_BE_FIXED
             count: TO_BE_FIXED
             javaOpts: TO_BE_FIXED


### PR DESCRIPTION
* default value 가 TO_BE_FIXED면 boolean이 아닌 string으로 인식하여, kustomize build이후에 "true", "false"로 치환된다.
* resources.yaml의 boolean 기본 값은 true 혹은 false로 정의